### PR TITLE
Unlock Timestamps!

### DIFF
--- a/cmd/disable_timeout.go
+++ b/cmd/disable_timeout.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(disableTimeoutCmd)
+}
+
+var disableTimeoutCmd = &cobra.Command{
+	Use:    "disable-timeout",
+	Short:  "An easy way to set the disable the unlock timeout feature.",
+	PreRun: toggleDebug,
+	Run: func(cmd *cobra.Command, args []string) {
+		nativeCmd = true
+		err := disableTimeout()
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func disableTimeout() error {
+
+	config, err := getViperConfig()
+	if err != nil {
+		return err
+	}
+
+	log.Info("Disabling Unlock Timeouts...")
+	config.UnlockTimeoutPeriod = ""
+	WriteToConfig(config)
+
+	return nil
+}

--- a/cmd/kubectl.go
+++ b/cmd/kubectl.go
@@ -341,6 +341,7 @@ func findContextInConfig(kubeContext string, config KubeLockConfig) (string, int
 
 		if time.Now().Sub(timestampTime) > unlockTimeout {
 			log.Error("Halt! Unlock for Context '", kubeContext, "' has expired (times out after ", unlockTimeout.String(), "). Setting status of context back to 'locked' and exiting...")
+			setContextStatus(kubeContext, contextIndex, "locked", config)
 			os.Exit(1)
 		}
 	}

--- a/cmd/kubectl.go
+++ b/cmd/kubectl.go
@@ -294,10 +294,12 @@ func findContextInConfig(kubeContext string, config KubeLockConfig) (string, int
 	// Getting the lock status for current context
 	var status string
 	var contextIndex int
+	var unlockTimestamp string
 	var found bool
 	for i, context := range config.Contexts {
 		if context.Name == kubeContext {
 			status = config.Contexts[i].Status
+			unlockTimestamp = config.Contexts[i].UnlockTimestamp
 			found = true
 			contextIndex = i
 			break
@@ -325,6 +327,12 @@ func findContextInConfig(kubeContext string, config KubeLockConfig) (string, int
 		os.Exit(1)
 	}
 
+	// If the timestamp found in the contexts status is older than the timeout period set, exit
+	timestampTime, err := time.Parse(timestampLayout, unlockTimestamp)
+	if err != nil {
+		return status, contextIndex, err
+	}
+	unlockTimeout, err := time.ParseDuration(config.UnlockTimeoutPeriod)
 	return status, contextIndex, nil
 }
 

--- a/cmd/kubectl.go
+++ b/cmd/kubectl.go
@@ -16,14 +16,19 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const (
+	timestampLayout = "2006-01-02T15:04:05Z07:00"
+)
+
 func getDeleteBoolFlags() []string {
 	return []string{"--all", "--all-namespaces", "--force", "--ignore-not-found", "--now", "--recursive", "-R", "--wait"}
 }
 
 type KubeLockConfig struct {
-	Contexts       []KubeLockContexts `yaml: "contexts"`
-	Profiles       []KubeLockProfiles `yaml: "profiles"`
-	DefaultProfile string             `yaml: "defaultProfile"`
+	Contexts            []KubeLockContexts `yaml: "contexts"`
+	Profiles            []KubeLockProfiles `yaml: "profiles"`
+	DefaultProfile      string             `yaml: "defaultProfile"`
+	UnlockTimeoutPeriod string             `yaml: "unlockTimeoutPeriod"`
 }
 
 type KubeLockContexts struct {

--- a/cmd/lock.go
+++ b/cmd/lock.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"time"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -49,6 +51,13 @@ func setLock(cmd *cobra.Command, args []string) error {
 }
 
 func setContextStatus(kubeContext string, index int, status string, config KubeLockConfig) {
+	if status == ("unlocked") && config.Contexts[index].Status == "locked" {
+		log.Debug("Setting context from 'locked' to 'unlocked', marking unlock Timestamp to check for timeout later...")
+		config.Contexts[index].UnlockTimestamp = time.Now().Format(timestampLayout)
+	} else if config.Contexts[index].UnlockTimestamp != "" {
+		log.Debug("Clearing unlock timestamp...")
+		config.Contexts[index].UnlockTimestamp = ""
+	}
 	config.Contexts[index].Status = status
 	WriteToConfig(config)
 	log.Info("Set context '", kubeContext, "' to ", status, ".")

--- a/cmd/set_timeout.go
+++ b/cmd/set_timeout.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(setTimeoutCmd)
+}
+
+var setTimeoutCmd = &cobra.Command{
+	Use:    "set-timeout",
+	Short:  "An easy way to set the unlock timeout duration (e.g. '10s', '10m', '10h' etc.).",
+	PreRun: toggleDebug,
+	Run: func(cmd *cobra.Command, args []string) {
+		nativeCmd = true
+		err := setTimeout(cmd, args)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func setTimeout(cmd *cobra.Command, args []string) error {
+	var err error
+	newTimeout := args[0]
+
+	config, err := getViperConfig()
+	if err != nil {
+		return err
+	}
+
+	log.Info("Setting new Unlock Timeout Period to '", newTimeout, "'...")
+	_, err = time.ParseDuration(newTimeout)
+	if err != nil {
+		log.Error("Provided Timeout Value '", newTimeout, "' not provided correctly... Exiting")
+		return err
+	}
+
+	config.UnlockTimeoutPeriod = newTimeout
+	WriteToConfig(config)
+
+	return nil
+}


### PR DESCRIPTION
This is so users can configure a timeout that will automatically switch the context back to `locked` if the `unlock` command was issued an amount of minutes or hours previous.